### PR TITLE
Bump actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Run Ruby tests and linter
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 10 # this might cause issues if there are more than 10 commits in a PR (?)
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This fixes a deprecation warning about "Node.js 16 actions are deprecated".