### PR TITLE
Normalize platforms in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,8 @@ GEM
     uri (1.0.2)
 
 PLATFORMS
-  x86_64-darwin-20
+  ruby
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
`bundle lock --normalize-platforms`

Suggested by: https://mensfeld.pl/2025/01/the-silent-guardian-why-bundler-checksums-are-a-game-changer-for-your-applications/